### PR TITLE
Remove support for inner attributes on non-block expressions

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -117,7 +117,6 @@ impl Printer {
         self.word("[");
         self.cbox(INDENT);
         self.zerobreak();
-        self.inner_attrs(&expr.attrs);
         for element in expr.elems.iter().delimited() {
             self.expr(&element);
             self.trailing_comma(element.is_last);
@@ -504,7 +503,6 @@ impl Printer {
     fn expr_paren(&mut self, expr: &ExprParen) {
         self.outer_attrs(&expr.attrs);
         self.word("(");
-        self.inner_attrs(&expr.attrs);
         self.expr(&expr.expr);
         self.word(")");
     }
@@ -540,7 +538,6 @@ impl Printer {
     fn expr_repeat(&mut self, expr: &ExprRepeat) {
         self.outer_attrs(&expr.attrs);
         self.word("[");
-        self.inner_attrs(&expr.attrs);
         self.expr(&expr.expr);
         self.word("; ");
         self.expr(&expr.len);
@@ -564,7 +561,6 @@ impl Printer {
         self.end();
         self.word(" {");
         self.space_if_nonempty();
-        self.inner_attrs(&expr.attrs);
         for field_value in expr.fields.iter().delimited() {
             self.field_value(&field_value);
             self.trailing_comma_or_space(field_value.is_last && expr.rest.is_none());
@@ -603,7 +599,6 @@ impl Printer {
         self.word("(");
         self.cbox(INDENT);
         self.zerobreak();
-        self.inner_attrs(&expr.attrs);
         for elem in expr.elems.iter().delimited() {
             self.expr(&elem);
             if expr.elems.len() == 1 {

--- a/src/item.rs
+++ b/src/item.rs
@@ -64,7 +64,6 @@ impl Printer {
         self.where_clause_for_body(&item.generics.where_clause);
         self.word("{");
         self.hardbreak_if_nonempty();
-        self.inner_attrs(&item.attrs);
         for variant in &item.variants {
             self.variant(variant);
             self.word(",");

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -154,7 +154,6 @@ impl Printer {
         self.word("(");
         self.cbox(INDENT);
         self.zerobreak();
-        self.inner_attrs(&pat.attrs);
         for elem in pat.elems.iter().delimited() {
             self.pat(&elem);
             if pat.elems.len() == 1 {
@@ -177,7 +176,6 @@ impl Printer {
         self.word("(");
         self.cbox(INDENT);
         self.zerobreak();
-        self.inner_attrs(&pat.attrs);
         for elem in pat.pat.elems.iter().delimited() {
             self.pat(&elem);
             self.trailing_comma(elem.is_last);


### PR DESCRIPTION
This syntax has been removed from Rust. See https://github.com/rust-lang/rust/pull/83312 and https://github.com/dtolnay/syn/pull/1146.