### PR TITLE
Recognize Group(Verbatim) for comments at the tail of a block

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -833,14 +833,17 @@ impl Printer {
         if attr::has_inner(attrs) || !block.stmts.is_empty() {
             self.space();
             self.inner_attrs(attrs);
-            if let (Some(Stmt::Expr(expr)), None) = (block.stmts.get(0), block.stmts.get(1)) {
-                self.ibox(0);
-                self.expr_beginning_of_line(expr, true);
-                self.end();
-                self.space();
-            } else {
-                for stmt in &block.stmts {
-                    self.stmt(stmt);
+            match (block.stmts.get(0), block.stmts.get(1)) {
+                (Some(Stmt::Expr(expr)), None) if stmt::break_after(expr) => {
+                    self.ibox(0);
+                    self.expr_beginning_of_line(expr, true);
+                    self.end();
+                    self.space();
+                }
+                _ => {
+                    for stmt in &block.stmts {
+                        self.stmt(stmt);
+                    }
                 }
             }
             self.offset(-INDENT);

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -20,13 +20,17 @@ impl Printer {
             }
             Stmt::Item(item) => self.item(item),
             Stmt::Expr(expr) => {
-                self.ibox(0);
-                self.expr_beginning_of_line(expr, true);
-                if add_semi(expr) {
-                    self.word(";");
+                if break_after(expr) {
+                    self.ibox(0);
+                    self.expr_beginning_of_line(expr, true);
+                    if add_semi(expr) {
+                        self.word(";");
+                    }
+                    self.end();
+                    self.hardbreak();
+                } else {
+                    self.expr_beginning_of_line(expr, true);
                 }
-                self.end();
-                self.hardbreak();
             }
             Stmt::Semi(expr, _semi) => {
                 if let Expr::Verbatim(tokens) = expr {
@@ -57,6 +61,15 @@ pub fn add_semi(expr: &Expr) -> bool {
         Expr::Group(group) => add_semi(&group.expr),
         _ => false,
     }
+}
+
+pub fn break_after(expr: &Expr) -> bool {
+    if let Expr::Group(group) = expr {
+        if let Expr::Verbatim(verbatim) = group.expr.as_ref() {
+            return !verbatim.is_empty();
+        }
+    }
+    true
 }
 
 fn remove_semi(expr: &Expr) -> bool {


### PR DESCRIPTION
```rust
print!("{}", prettyplease::unparse(&syn::File {
    shebang: None,
    attrs: Vec::new(),
    items: vec![syn::Item::Const(syn::ItemConst {
        attrs: Vec::new(),
        vis: syn::Visibility::Inherited,
        const_token: syn::parse_quote!(const),
        ident: <syn::Ident as From<syn::Token![_]>>::from(syn::parse_quote!(_)),
        colon_token: syn::parse_quote!(:),
        ty: syn::parse_quote!(()),
        eq_token: syn::parse_quote!(=),
        expr: Box::new(syn::Expr::Block(syn::ExprBlock {
            attrs: Vec::new(),
            label: None,
            block: syn::Block {
                brace_token: Default::default(),
                stmts: vec![syn::Stmt::Expr(syn::Expr::Group(syn::ExprGroup {
                    attrs: vec![syn::parse_quote!(#[comment = " stuff"])],
                    group_token: Default::default(),
                    expr: Box::new(syn::Expr::Verbatim(syn::parse_quote!())),
                }))],
            },
        })),
        semi_token: syn::parse_quote!(;),
    })],
}));
```

```console
const _: () = {
    // stuff
};
```

Prior to this PR, the same code would put an unneeded trailing blank line.

```console
const _: () = {
    // stuff

};
```