### PR TITLE
Support named variadic function arguments

### DIFF
--- a/src/ty.rs
+++ b/src/ty.rs
@@ -163,7 +163,11 @@ impl Printer {
     }
 
     fn type_verbatim(&mut self, ty: &TokenStream) {
-        unimplemented!("Type::Verbatim `{}`", ty);
+        if ty.to_string() == "..." {
+            self.word("...");
+        } else {
+            unimplemented!("Type::Verbatim `{}`", ty);
+        }
     }
 
     pub fn return_type(&mut self, ty: &ReturnType) {


### PR DESCRIPTION
```rust
const INPUT: &str = stringify! {
    unsafe extern "C" fn variadic(first: c_int, #[attr] mut rest: ...) {}
};

fn main() {
    let syntax_tree = syn::parse_file(INPUT).unwrap();
    let formatted = prettyplease::unparse(&syntax_tree);
    print!("{}", formatted);
}
```

```console
unsafe extern "C" fn variadic(first: c_int, #[attr] mut rest: ...) {}
```