### PR TITLE
Fix indentation of multiline return types

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -737,7 +737,9 @@ impl Printer {
         self.offset(-INDENT);
         self.end();
         self.word(")");
+        self.cbox(-INDENT);
         self.return_type(&signature.output);
+        self.end();
     }
 
     fn receiver(&mut self, receiver: &Receiver) {


### PR DESCRIPTION
Before:

```rust
pub async fn stream(
    self,
) -> Result<
        impl futures::Stream<Item = Result<T, tokio_postgres::Error>>,
        tokio_postgres::Error,
    > {
    let stmt = self.stmt().await?;
}
```

After: this matches `rustfmt`'s formatting.

```rust
pub async fn stream(
    self,
) -> Result<
    impl futures::Stream<Item = Result<T, tokio_postgres::Error>>,
    tokio_postgres::Error,
> {
    let stmt = self.stmt().await?;
}
```