### PR TITLE
Expose prettyplease version number for downstream build.rs to inspect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "A minimal `syn` syntax tree pretty-printer"
 repository = "https://github.com/dtolnay/prettyplease"
 documentation = "https://docs.rs/prettyplease"
 readme = "README.md"
+links = "prettyplease01"
 autoexamples = false
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!(concat!("cargo:VERSION=", env!("CARGO_PKG_VERSION")));
+}


### PR DESCRIPTION
What version of the formatter a generated file has been formatted with can be relevant.

In cargo-expand I'd like to include this number in the output of `--version --verbose`.