### PR TITLE
Update the type alias's `where` clause position according to rust-lang issue #89122

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -307,13 +307,12 @@ impl Printer {
         self.word("type ");
         self.ident(&item.ident);
         self.generics(&item.generics);
-        self.word("= ");
+        self.word(" = ");
         self.neverbreak();
         self.ibox(-INDENT);
         self.ty(&item.ty);
         self.end();
-        self.where_clause_oneline(&item.generics.where_clause);
-        self.word(";");
+        self.where_clause_oneline_semi(&item.generics.where_clause);
         self.end();
         self.hardbreak();
     }
@@ -631,10 +630,10 @@ impl Printer {
             self.type_param_bound(&bound);
         }
         if let Some((_eq_token, default)) = &trait_item.default {
-            self.where_clause_oneline(&trait_item.generics.where_clause);
-            self.word("= ");
+            self.word(" = ");
             self.neverbreak();
             self.ty(default);
+            self.where_clause_oneline_semi(&trait_item.generics.where_clause);
         } else {
             self.where_clause_oneline_semi(&trait_item.generics.where_clause);
         }
@@ -728,13 +727,12 @@ impl Printer {
         self.word("type ");
         self.ident(&impl_item.ident);
         self.generics(&impl_item.generics);
-        self.word("= ");
+        self.word(" = ");
         self.neverbreak();
         self.ibox(-INDENT);
         self.ty(&impl_item.ty);
         self.end();
-        self.where_clause_oneline(&impl_item.generics.where_clause);
-        self.word(";");
+        self.where_clause_oneline_semi(&impl_item.generics.where_clause);
         self.end();
         self.hardbreak();
     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -307,12 +307,12 @@ impl Printer {
         self.word("type ");
         self.ident(&item.ident);
         self.generics(&item.generics);
-        self.where_clause_oneline(&item.generics.where_clause);
         self.word("= ");
         self.neverbreak();
         self.ibox(-INDENT);
         self.ty(&item.ty);
         self.end();
+        self.where_clause_oneline(&item.generics.where_clause);
         self.word(";");
         self.end();
         self.hardbreak();
@@ -728,12 +728,12 @@ impl Printer {
         self.word("type ");
         self.ident(&impl_item.ident);
         self.generics(&impl_item.generics);
-        self.where_clause_oneline(&impl_item.generics.where_clause);
         self.word("= ");
         self.neverbreak();
         self.ibox(-INDENT);
         self.ty(&impl_item.ty);
         self.end();
+        self.where_clause_oneline(&impl_item.generics.where_clause);
         self.word(";");
         self.end();
         self.hardbreak();


### PR DESCRIPTION
Hello! 😀
When I'm using this formatter I noticed it's not yet supporting [the recent rust's syntax update](https://github.com/rust-lang/rust/issues/89122).
So I'm sending you a small patch to fix it. Thanks! 🙇

Sample diff from my code:
https://user-images.githubusercontent.com/1488411/210623996-300f6a29-f730-4e1d-a16f-d95133b66f91.png
(My test cases is not enough I think, I only tested the type alias in impl_item. But it's trivial so assume it's okay...)