### PR TITLE
Improve let-else formatting

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -15,9 +15,14 @@ impl Printer {
                     self.neverbreak();
                     self.expr(&local_init.expr);
                     if let Some((_else, diverge)) = &local_init.diverge {
-                        self.word(" else ");
+                        self.space();
+                        self.word("else ");
+                        self.end();
+                        self.neverbreak();
                         if let Expr::Block(expr) = diverge.as_ref() {
+                            self.cbox(INDENT);
                             self.small_block(&expr.block, &[]);
+                            self.end();
                         } else {
                             self.word("{");
                             self.space();
@@ -28,10 +33,13 @@ impl Printer {
                             self.offset(-INDENT);
                             self.word("}");
                         }
+                    } else {
+                        self.end();
                     }
+                } else {
+                    self.end();
                 }
                 self.word(";");
-                self.end();
                 self.hardbreak();
             }
             Stmt::Item(item) => self.item(item),


### PR DESCRIPTION
Fixes #55.

The following styles are all mirrored from rustfmt.

```rust
impl op_v8_string {
    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
        let result = {
            let Ok(arg0) = v8_convert(arg0) else { return };
            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<T>(arg0) else {
                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                return;
            };
            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<deno_core::String>(arg0)
            else {
                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                return;
            };
            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                deno_core::v8::String,
            >(arg00000000000000000000000000) else {
                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                return;
            };
        };
    }
}
```