### PR TITLE
Add test of parenthesization of struct lit in match guard

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -25,3 +25,33 @@ fn test_parenthesize_cond() {
         "},
     );
 }
+
+#[test]
+fn test_parenthesize_match_guard() {
+    let expr_struct = Group::new(Delimiter::None, quote!(Struct {}));
+    let expr_binary = Group::new(Delimiter::None, quote!(true && false));
+    test(
+        quote! {
+            fn main() {
+                match () {
+                    () if let _ = #expr_struct => {}
+                    () if let _ = #expr_binary => {}
+                }
+            }
+        },
+        // FIXME: no parens around `Struct {}` because anything until the `=>`
+        // is considered part of the match guard expression. Parsing of the
+        // expression is not terminated by `{` in that position.
+        //
+        // FIXME: the `true && false` needs parens. Otherwise the precedence is
+        // `(let _ = true) && false` which means something different.
+        indoc! {"
+            fn main() {
+                match () {
+                    () if let _ = (Struct {}) => {}
+                    () if let _ = true && false => {}
+                }
+            }
+        "},
+    );
+}


### PR DESCRIPTION
There is both a false positive and a false negative in the parenthesization.