### PR TITLE
Use $CARGO_PKG_VERSION from buildscript exec-time instead of build-time

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,7 @@
+use std::env;
+use std::ffi::OsString;
+use std::process;
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
@@ -5,5 +9,13 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(prettyplease_debug)");
     println!("cargo:rustc-check-cfg=cfg(prettyplease_debug_indent)");
 
-    println!(concat!("cargo:VERSION=", env!("CARGO_PKG_VERSION")));
+    let pkg_version = cargo_env_var("CARGO_PKG_VERSION");
+    println!("cargo:VERSION={}", pkg_version.to_str().unwrap());
+}
+
+fn cargo_env_var(key: &str) -> OsString {
+    env::var_os(key).unwrap_or_else(|| {
+        eprintln!("Environment variable ${key} is not set during execution of build script");
+        process::exit(1);
+    })
 }


### PR DESCRIPTION
See https://doc.rust-lang.org/1.82.0/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts. This better aligns with Cargo's documented API for build scripts.

> _Cargo sets several environment variables when build scripts are run. Because these variables are not yet set when the build script is compiled, the above example using `env!` won’t work and instead you’ll need to retrieve the values when the build script is run:_