### PR TITLE
Avoid trailing '.' on non-macro float literals

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -44,7 +44,12 @@ impl Printer {
     }
 
     fn lit_float(&mut self, lit: &LitFloat) {
-        self.word(lit.token().to_string());
+        let repr = lit.token().to_string();
+        let dot = repr.ends_with('.');
+        self.word(repr);
+        if dot {
+            self.word("0");
+        }
     }
 
     fn lit_bool(&mut self, lit: &LitBool) {

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -179,6 +179,7 @@ impl Printer {
                 (_, Token::Ident(ident)) if !is_keyword(ident) => {
                     (state != Dot && state != Colon2, Ident)
                 }
+                (_, Token::Literal(lit)) if lit.to_string().ends_with('.') => (state != Dot, Other),
                 (_, Token::Literal(_)) => (state != Dot, Ident),
                 (_, Token::Punct(',' | ';', _)) => (false, Other),
                 (_, Token::Punct('.', _)) if !matcher => (state != Ident && state != Delim, Dot),


### PR DESCRIPTION
This prevents `(0.).to_string()` from being printed as a range expression: `0..to_string()`.