### PR TITLE
Separate consecutive ranges with a space

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -211,9 +211,18 @@ impl Printer {
         self.scan_end();
     }
 
+    pub fn ends_with(&self, ch: char) -> bool {
+        for i in self.buf.index_range().rev() {
+            if let Token::String(token) = &self.buf[i].token {
+                return token.ends_with(ch);
+            }
+        }
+        self.out.ends_with(ch)
+    }
+
     fn check_stream(&mut self) {
         while self.right_total - self.left_total > self.space {
-            if *self.scan_stack.front().unwrap() == self.buf.index_of_first() {
+            if *self.scan_stack.front().unwrap() == self.buf.index_range().start {
                 self.scan_stack.pop_front().unwrap();
                 self.buf.first_mut().size = SIZE_INFINITY;
             }

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, Range};
 
 pub struct RingBuffer<T> {
     data: VecDeque<T>,
@@ -33,8 +33,8 @@ impl<T> RingBuffer<T> {
         self.data.clear();
     }
 
-    pub fn index_of_first(&self) -> usize {
-        self.offset
+    pub fn index_range(&self) -> Range<usize> {
+        self.offset..self.offset + self.data.len()
     }
 
     pub fn first(&self) -> &T {


### PR DESCRIPTION
Previously the expression `..(..)` would print as `....`, which the parser cannot handle.

```console
error: unexpected token: `...`
 --> src/main.rs:2:13
  |
2 |     let _ = ....;
  |             ^^^
  |
help: use `..` for an exclusive range
  |
2 |     let _ = ...;
  |             ~~
help: or `..=` for an inclusive range
  |
2 |     let _ = ..=.;
  |             ~~~

error[E0586]: inclusive range with no end
 --> src/main.rs:2:13
  |
2 |     let _ = ....;
  |             ^^^
  |
  = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
help: use `..` instead
  |
2 -     let _ = ....;
2 +     let _ = ...;
  |

error: expected one of `;` or `else`, found `.`
 --> src/main.rs:2:16
  |
2 |     let _ = ....;
  |                ^ expected one of `;` or `else`
```