### PR TITLE
Support multi-char post_break

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -19,7 +19,7 @@ pub struct BreakToken {
     pub offset: isize,
     pub blank_space: usize,
     pub pre_break: Option<char>,
-    pub post_break: Option<char>,
+    pub post_break: &'static str,
     pub no_break: Option<char>,
     pub if_nonempty: bool,
     pub never_break: bool,
@@ -362,10 +362,10 @@ impl Printer {
             let indent = self.indent as isize + token.offset;
             self.pending_indentation = usize::try_from(indent).unwrap();
             self.space = cmp::max(MARGIN - indent, MIN_SPACE);
-            if let Some(post_break) = token.post_break {
+            if !token.post_break.is_empty() {
                 self.print_indent();
-                self.out.push(post_break);
-                self.space -= post_break.len_utf8() as isize;
+                self.out.push_str(token.post_break);
+                self.space -= token.post_break.len() as isize;
             }
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -423,7 +423,7 @@ impl Printer {
                     self.scan_break(BreakToken {
                         offset: -INDENT,
                         pre_break: (okay_to_brace && stmt::add_semi(&expr.body)).then_some(';'),
-                        post_break: Some(if okay_to_brace { '}' } else { ')' }),
+                        post_break: if okay_to_brace { "}" } else { ")" },
                         ..BreakToken::default()
                     });
                     self.end();
@@ -1129,7 +1129,7 @@ impl Printer {
             self.scan_break(BreakToken {
                 offset: -INDENT,
                 pre_break: stmt::add_semi(body).then_some(';'),
-                post_break: Some('}'),
+                post_break: "}",
                 no_break: classify::requires_comma_to_be_match_arm(body).then_some(','),
                 ..BreakToken::default()
             });


### PR DESCRIPTION
This is going to be needed for `),` post-break on certain match arms.