### PR TITLE
Skip `cargo test --release` on old rustc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       - run: cargo test --release --test test_precedence
         env:
           RUSTFLAGS: ${{env.RUSTFLAGS}} ${{matrix.rust == 'nightly' && '--cfg exhaustive' || ''}}
+        if: matrix.rust != '1.62.0'
       - uses: actions/upload-artifact@v4
         if: matrix.rust == 'nightly' && always()
         with:


### PR DESCRIPTION
The 1.62 CI is by far the slowest CI job due to the lack of Cargo sparse registry protocol (Rust 1.68+). This PR will speed up overall CI time by 25 seconds for no meaningful loss in coverage.

<p align="center"><img src="https://github.com/user-attachments/assets/f1de45c4-6310-4b8a-863f-2cc60da7f73a" width="500"></p>

