### PR TITLE
Revert "Avoid trailing '.' on non-macro float literals"

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -44,12 +44,7 @@ impl Printer {
     }
 
     fn lit_float(&mut self, lit: &LitFloat) {
-        let repr = lit.token().to_string();
-        let dot = repr.ends_with('.');
-        self.word(repr);
-        if dot {
-            self.word("0");
-        }
+        self.word(lit.token().to_string());
     }
 
     fn lit_bool(&mut self, lit: &LitBool) {


### PR DESCRIPTION
https://github.com/dtolnay/prettyplease/pull/89 is superseded by https://github.com/dtolnay/prettyplease/pull/92.