### PR TITLE
Forbid block comments that end in a slash.

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -269,6 +269,11 @@ fn can_be_block_comment(value: &str) -> bool {
     let mut i = 0usize;
     let upper = bytes.len() - 1;
 
+    if value.ends_with('/') {
+        // following `*` would start a nested comment
+        return false;
+    }
+
     while i < upper {
         if bytes[i] == b'/' && bytes[i + 1] == b'*' {
             depth += 1;


### PR DESCRIPTION
Otherwise, 
```rust
#[doc("foo\nbar/")]
```
 would produce an unclosed nested block comment:
```
/**foo
bar/*/
```